### PR TITLE
feat: add Alliteration strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ The script uses [urbit-wordlists](https://github.com/ashelkovnykov/urbit-wordlis
 - *AnyApprox*:  at least one segment matches `wordlists/name/approx-single` or `wordlists/name/approx-double`.
 - *OnlyApprox*:  both segments match any of the wordlists.
 - *Doubles*: both segments are identical (e.g., ~datnut-datnut)
+- *Alliteration*: both segments start with the same letter (e.g., ~bacbel-baldut)
 
 
-Output for each is written to `./output/[star]/[strategy]_planets.txt`, for 5 total files per run.
+Output for each is written to `./output/[star]/[strategy]_planets.txt`, for 6 total files per run.
 
 ## Special Thanks
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ const (
 	OnlyApprox
 	OnlyEnglish
 	Doubles
+	Alliteration
 )
 
 type StrategyPrompt struct {
@@ -48,6 +49,9 @@ var strategyPrompts = []StrategyPrompt{
 	},
 	{
 		"Doubles", Doubles,
+	},
+	{
+		"Alliteration", Alliteration,
 	},
 }
 
@@ -137,6 +141,13 @@ func doubles(planet string) bool {
 	return parts[0] == parts[1]
 }
 
+func alliteration(planet string) bool {
+	deSigged := strings.Replace(planet, "~", "", 1)
+	parts := strings.Split(deSigged, "-")
+
+	return parts[0][0] == parts[1][0]
+}
+
 // generates list of planets under parent
 func makePlanets(parent string) []string {
 	fmt.Sprintf("Making planet list for %s ...\n", parent)
@@ -200,6 +211,12 @@ func filterPlanets(planets []string, strategy Strategy) []string {
 
 		case Doubles:
 			if doubles(p) {
+				output = append(output, p)
+			}
+			continue
+
+		case Alliteration:
+			if alliteration(p) {
 				output = append(output, p)
 			}
 			continue
@@ -280,6 +297,7 @@ func main() {
 	anyEnglishPlanets := filterPlanets(planets, AnyEnglish)
 	onlyEnglishPlanets := filterPlanets(planets, OnlyEnglish)
 	doublesPlanets := filterPlanets(planets, Doubles)
+	alliterationPlanets := filterPlanets(planets, Alliteration)
 
 	// write output
 	_, oErr := os.Stat("output")
@@ -297,6 +315,7 @@ func main() {
 	writeResults(deSiggedParent, "any_english", anyEnglishPlanets)
 	writeResults(deSiggedParent, "only_english", onlyEnglishPlanets)
 	writeResults(deSiggedParent, "doubles", doublesPlanets)
+	writeResults(deSiggedParent, "alliteration", alliterationPlanets)
 
 	fmt.Println("Done :)")
 }


### PR DESCRIPTION
## Summary
- Add `Alliteration` strategy that matches planets where both segments start with the same letter (e.g., `~bacbel-baldut`)
- Follows existing strategy pattern: const, filter func, switch case, output file
- Update README with new strategy description

Ref #11 (alliteration portion)

## Test plan
- [x] `go build` succeeds
- [x] `./gonetia "~marzod"` produces `output/marzod/alliteration_planets.txt`
- [x] Output entries all have matching first letters across segments (5,666 matches for ~marzod)